### PR TITLE
Add Structured Cloudevent data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+dependency-cache/
+.DS_Store
+artifactory/
+.vscode/
+node-fn-structured-cloudevent-buildpack-*.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+VERSION := "v$$(cat buildpack.toml | grep -m 1 version | sed -e 's/version = //g' | xargs)"
+
+package:
+	@tar cvzf node-fn-structured-cloudevent-buildpack-$(VERSION).tgz bin/ buildpack.toml README.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `node-fn-structured-cloudevent-buildpack`
+# Heroku Buildpack for Structured Cloudevents in Node Functions
 
 This buildpack provides a node function middleware that extracts structured
 cloudevents `data` from the structured wrapper.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# Heroku Buildpack for Structured Cloudevents in Node Functions
+# Node Function Structured Cloudevent Middleware
 
 This buildpack provides a node function middleware that extracts structured
 cloudevents `data` from the structured wrapper.
 
 This is useful if you are using node-function-buildpack in a situation where
-the function may recieve both structured and binary cloudevents, but you'd like to
-use the same function signature.
+the function may recieve both structured and binary cloudevents, but you don't
+want to handle two different payload structures.
+
+### Usage
+
+*With `pack`:*
+
+`pack build --builder heroku/buildpacks:18 --buildpack heroku/nodejs --buildpack heroku/node-function-buildpack --buildpack https://github.com/heroku/node-fn-structured-cloudevent-buildpack`

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# node-fn-structured-cloudevent-buildpack
+# `node-fn-structured-cloudevent-buildpack`
+
+This buildpack provides a node function middleware that extracts structured
+cloudevents `data` from the structured wrapper.
+
+This is useful if you are using node-function-buildpack in a situation where
+the function may recieve both structured and binary cloudevents, but you'd like to
+use the same function signature.

--- a/bin/build
+++ b/bin/build
@@ -5,8 +5,6 @@ BP_DIR=$(cd $(dirname $0)/..; pwd)
 LAYERS_DIR="$1"
 MW_LAYER="$LAYERS_DIR/middleware"
 
-echo "doing stuff in $MW_LAYER"
-
 mkdir -p "$MW_LAYER/env"
 
 cp "$BP_DIR/index.js" $MW_LAYER

--- a/bin/build
+++ b/bin/build
@@ -10,5 +10,4 @@ mkdir -p "$MW_LAYER/env"
 cp "$BP_DIR/index.js" $MW_LAYER
 
 echo -n "$MW_LAYER/index.js" > "$MW_LAYER/env/MIDDLEWARE_FUNCTION_URI"
-echo "launch = true" >> "$MW_LAYER.toml"
-echo "build = true" >> "$MW_LAYER.toml"
+echo "launch = true" > "$MW_LAYER.toml"

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+BP_DIR=$(cd $(dirname $0)/..; pwd)
+LAYERS_DIR="$1"
+MW_LAYER="$LAYERS_DIR/middleware"
+
+echo "doing stuff in $MW_LAYER"
+
+mkdir -p "$MW_LAYER/env"
+
+cp "$BP_DIR/index.js" $MW_LAYER
+
+echo -n "$MW_LAYER/index.js" > "$MW_LAYER/env/MIDDLEWARE_FUNCTION_URI"
+echo "launch = true" >> "$MW_LAYER.toml"
+echo "build = true" >> "$MW_LAYER.toml"
+
+cat $MW_LAYER.toml
+
+echo "Stuff in $MW_LAYER:"
+ls $MW_LAYER

--- a/bin/build
+++ b/bin/build
@@ -12,8 +12,3 @@ cp "$BP_DIR/index.js" $MW_LAYER
 echo -n "$MW_LAYER/index.js" > "$MW_LAYER/env/MIDDLEWARE_FUNCTION_URI"
 echo "launch = true" >> "$MW_LAYER.toml"
 echo "build = true" >> "$MW_LAYER.toml"
-
-cat $MW_LAYER.toml
-
-echo "Stuff in $MW_LAYER:"
-ls $MW_LAYER

--- a/bin/detect
+++ b/bin/detect
@@ -2,6 +2,7 @@
 set -eo pipefail
 
 if [ -f package.json ]; then
+  echo "node-fn-structured-cloudevent"
   exit 0
 else
   exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -2,7 +2,6 @@
 set -eo pipefail
 
 if [ -f package.json ]; then
-  echo "node-fn-structured-cloudevent"
   exit 0
 else
   exit 1

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [ -f package.json ]; then
+  echo "node-fn-structured-cloudevent"
+  exit 0
+else
+  exit 1
+fi

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.1"
+
+[buildpack]
+id = "heroku/node-fn-structured-cloudevent"
+name = "Node Function Structured Cloudevent Middleware"
+version = "0.0.1"
+
+[[stacks]]
+id = "heroku-18"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+module.exports = async ({headers}, _state, args) => {
+  const payload = args[0];
+  const structured = headers.hasOwnProperty('content-type') &&
+    headers['content-type'].indexOf('application/cloudevents+json') > -1 &&
+    typeof payload == "object" && payload.hasOwnProperty('data')
+  if (structured) {
+    return [payload.data];
+  } else {
+    return args;
+  }
+}


### PR DESCRIPTION
This implements a node-function-buildpack middleware to help with handling of structured cloudevents.

When receiving a binary cloudevent, the payload is provided directly to the function, for example,`{"foo": "bar"}`. However, when receiving a structured cloudevent the function recieves the wrapper too.

```json
{
    "specversion" : "1.0-rc1",
    "type" : "com.github.pull.create",
    "id" : "A234-1234-1234",
    "time" : "2018-04-05T17:31:00Z",
    "datacontenttype" : "application/json",
    "data" : {"foo": "bar"}
}
```

This middleware removes the wrapper when detected, so that users may write the same function against both structured and binary cloudevents.

Note that this depends on https://github.com/heroku/node-function-buildpack/pull/31.